### PR TITLE
Add slack self invite badge

### DIFF
--- a/participation/index.html
+++ b/participation/index.html
@@ -85,7 +85,8 @@
         If you're interested in Data Science, get involved! There are many ways to contribute to the group and you don't even have to be a Data Scientist!
 		<h3>If you are...</h3>
 		<h4>Just curious</h4>
-		We're on slack! Join the conversation. This is a great way to meet the people in Norfolk Data Science and learn more about how you can participate. Just send a request to <a href="mailto:norfolkdatasci@gmail.com">NorfolkDataSci@gmail.com</a> and then check your email for an invite! 
+		We're on slack! Join the conversation. This is a great way to meet the people in Norfolk Data Science and learn more about how you can participate. Follow the slack link below or request an invite from <a href="mailto:norfolkdatasci@gmail.com">NorfolkDataSci@gmail.com</a><br>
+		<a href="https://norfolk-slack-invites.herokuapp.com" target="_blank"><img src="https://norfolk-slack-invites.herokuapp.com/badge.svg"></a> 
 		<h4>A Social Butterfly</h4>
 		Checkout our monthly meeting! All you need to do is head over to our <a target="_blank" href="http://www.meetup.com/Norfolk-Data-Science/">MeetUp page</a> and RSVP (and then show up, of course..).
 		<h4>A Coder</h4>


### PR DESCRIPTION
Add a slack self invite badge to allow users to request an invite without having to email. Close #13